### PR TITLE
fix/env-var-support

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,6 +3,9 @@ name: Deploy to GitHub Pages
 on:
   workflow_dispatch:
 
+env:
+  HOST: ${{ vars.HOST }}
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[add env var HOST build support](https://github.com/bsky-labs/oauth-playground/commit/8f62c65b98380d8331e33803a95bbdd5a48423f9)